### PR TITLE
Refine barcode navigation flow and add contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- App sources live under `IngrediCheck/`; SwiftUI screens sit in `Views/`, shared helpers in `Utilities/`, and observable state in `Store/` (e.g., `AuthController.swift`, `NetworkState.swift`).
+- Network access is handled by `WebService.swift` and `SupabaseRequestBuilder.swift`; keep API DTOs in `DTO.swift` to share models across features.
+- Assets and localized imagery are managed inside `Assets.xcassets`; update catalog groups rather than adding ad-hoc bundles.
+- Configuration constants (Supabase endpoints, analytics keys) are defined in `Config.swift`; use environment-specific overrides before shipping secrets.
+- CocoaPods outputs reside in `Pods/`; avoid editing generated files and commit only the lockfile when dependency versions change.
+
+## Build, Test, and Development Commands
+- `pod install` — resolve iOS dependencies; run after pod updates or Xcode version bumps.
+- `xed IngrediCheck.xcworkspace` — open the CocoaPods-integrated workspace in Xcode.
+- `xcodebuild build -workspace IngrediCheck.xcworkspace -scheme IngrediCheck -destination 'platform=iOS Simulator,name=iPhone 15'` — CI-friendly build to catch compile issues.
+- `xcodebuild test -workspace IngrediCheck.xcworkspace -scheme IngrediCheck -destination 'platform=iOS Simulator,name=iPhone 15'` — execute unit/UI tests once targets exist.
+
+## Coding Style & Naming Conventions
+- Follow Swift 5.9 defaults: four-space indentation, 120-char line guidance, and use trailing commas for multiline literals.
+- Types use `UpperCamelCase`, methods/properties use `lowerCamelCase`, and SwiftUI view files match the primary view name (e.g., `DisclaimerView.swift`).
+- Group extensions and previews with `// MARK:` comments for discoverability; prefer protocol-oriented patterns for shared behavior.
+- Run Xcode's “Re-Indent” and enable `swiftformat` or `SwiftLint` locally; do not commit warnings.
+
+## Testing Guidelines
+- Create `IngrediCheckTests` and `IngrediCheckUITests` targets for new coverage; mirror production folder names to keep scopes clear.
+- Use `XCTest` naming `test<Scenario>_<ExpectedBehavior>` and include async tests for Supabase/network flows.
+- Mock network dependencies via `WebService` protocols to avoid live Supabase hits; capture fixtures under `Tests/Fixtures`.
+- Aim for coverage of state stores (auth, onboarding, dietary preferences) and UI flows gating onboarding/consent screens.
+
+## Commit & Pull Request Guidelines
+- Prefer conventional titles with a leading area tag (`Feature:`, `Fix:`, `Chore:`) and optional issue references, mirroring recent history (`Feature: Switch to SSE API (#8)`).
+- Keep commits scoped to a single concern and include rationale in the body when touching config, analytics, or secrets.
+- PRs should summarize functional changes, list test evidence (`xcodebuild build`, `xcodebuild test`), link Supabase/issue tracker tasks, and add screenshots for UI updates.
+- Request at least one review, resolve Xcode warnings before merging, and ensure Pods/ and build settings remain in sync.

--- a/IngrediCheck/Views/BarcodeAnalysisView.swift
+++ b/IngrediCheck/Views/BarcodeAnalysisView.swift
@@ -144,7 +144,7 @@ struct StarButton: View {
 
 struct BarcodeAnalysisView: View {
     
-    @Binding var barcode: String?
+    let barcode: String
 
     @Environment(WebService.self) var webService
     @Environment(UserPreferences.self) var userPreferences
@@ -311,7 +311,7 @@ struct BarcodeAnalysisView: View {
                 } else {
                     VStack {
                         Spacer()
-                        Text("Looking up \(barcode!)")
+                        Text("Looking up \(barcode)")
                         Spacer()
                         ProgressView()
                         Spacer()
@@ -320,7 +320,7 @@ struct BarcodeAnalysisView: View {
             } else {
                 ProgressView()
                     .task {
-                        let newViewModel = BarcodeAnalysisViewModel(barcode!, webService, dietaryPreferences)
+                        let newViewModel = BarcodeAnalysisViewModel(barcode, webService, dietaryPreferences)
                         Task { await newViewModel.analyze() }
                         DispatchQueue.main.async { self.viewModel = newViewModel }
                     }

--- a/IngrediCheck/Views/BarcodeScannerView.swift
+++ b/IngrediCheck/Views/BarcodeScannerView.swift
@@ -163,7 +163,6 @@ struct DataScannerView: UIViewControllerRepresentable {
         }
         
         func dataScanner(_ dataScanner: DataScannerViewController, didAdd addedItems: [RecognizedItem], allItems: [RecognizedItem]) {
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
             if let firstItem = addedItems.first,
                case let .barcode(barcodeItem) = firstItem,
                let barcodeString = barcodeItem.payloadStringValue {
@@ -171,6 +170,7 @@ struct DataScannerView: UIViewControllerRepresentable {
                     return
                 }
                 routes.append(.barcode(barcodeString))
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
 
                 PostHogSDK.shared.capture("Barcode Scanning Completed", properties: [
                     "latency_ms": (Date().timeIntervalSince1970 * 1000) - (startTime * 1000),

--- a/IngrediCheck/Views/BarcodeScannerView.swift
+++ b/IngrediCheck/Views/BarcodeScannerView.swift
@@ -16,7 +16,6 @@ var startTime = Date().timeIntervalSince1970
 
 @MainActor struct BarcodeScannerView: View {
     
-    @Binding var barcode: String?
     @State private var dataScannerAccessStatus: DataScannerAccessStatusType = .notDetermined
     @State private var showScanner = true
 
@@ -71,7 +70,7 @@ var startTime = Date().timeIntervalSince1970
     
     private var mainView: some View {
         @Bindable var checkTabState = checkTabState
-        return DataScannerView(routes: $checkTabState.routes, barcode: $barcode)
+        return DataScannerView(routes: $checkTabState.routes)
             .aspectRatio(3/4, contentMode: .fit)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .overlay(
@@ -126,7 +125,6 @@ var startTime = Date().timeIntervalSince1970
 struct DataScannerView: UIViewControllerRepresentable {
     
     @Binding var routes: [CapturedItem]
-    @Binding var barcode: String?
 
     func makeUIViewController(context: Context) -> DataScannerViewController {
         let uiViewController = DataScannerViewController(
@@ -146,7 +144,7 @@ struct DataScannerView: UIViewControllerRepresentable {
     }
     
     func makeCoordinator() -> Coordinator {
-        return Coordinator(routes: $routes, barcode: $barcode)
+        return Coordinator(routes: $routes)
     }
     
     static func dismantleUIViewController(_ uiViewController: DataScannerViewController, coordinator: Coordinator) {
@@ -156,11 +154,9 @@ struct DataScannerView: UIViewControllerRepresentable {
     class Coordinator: NSObject, DataScannerViewControllerDelegate {
         
         @Binding var routes: [CapturedItem]
-        @Binding var barcode: String?
 
-        init(routes: Binding<[CapturedItem]>, barcode: Binding<String?>) {
+        init(routes: Binding<[CapturedItem]>) {
             self._routes = routes
-            self._barcode = barcode
         }
         
         func dataScanner(_ dataScanner: DataScannerViewController, didTapOn item: RecognizedItem) {
@@ -171,9 +167,11 @@ struct DataScannerView: UIViewControllerRepresentable {
             if let firstItem = addedItems.first,
                case let .barcode(barcodeItem) = firstItem,
                let barcodeString = barcodeItem.payloadStringValue {
-                self.barcode = barcodeString
-                self.routes.append(.barcode)
-                
+                if case .barcode(let lastBarcode) = routes.last, lastBarcode == barcodeString {
+                    return
+                }
+                routes.append(.barcode(barcodeString))
+
                 PostHogSDK.shared.capture("Barcode Scanning Completed", properties: [
                     "latency_ms": (Date().timeIntervalSince1970 * 1000) - (startTime * 1000),
                     "barcode_number": barcodeString

--- a/IngrediCheck/Views/CaptureView.swift
+++ b/IngrediCheck/Views/CaptureView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct CaptureView: View {
     
-    @Binding var barcode: String?
     @Environment(UserPreferences.self) var userPreferences
     @Environment(CheckTabState.self) var checkTabState
 
@@ -11,7 +10,7 @@ struct CaptureView: View {
         @Bindable var checkTabState = checkTabState
         VStack {
             if userPreferences.captureType == .barcode {
-                BarcodeScannerView(barcode: $barcode)
+                BarcodeScannerView()
             } else {
                 ImageCaptureView(
                     capturedImages: $checkTabState.capturedImages,

--- a/IngrediCheck/Views/Tabs/CheckTab.swift
+++ b/IngrediCheck/Views/Tabs/CheckTab.swift
@@ -8,18 +8,17 @@ struct ProductImage: Hashable {
 }
 
 enum CapturedItem: Hashable {
-    case barcode
+    case barcode(String)
     case productImages([ProductImage])
 }
 
 struct CheckTab: View {
-    @State private var barcode: String?
     @State private var checkTabState = CheckTabState()
 
     var body: some View {
         NavigationStack(path: $checkTabState.routes) {
             VStack {
-                CaptureView(barcode: $barcode)
+                CaptureView()
                 Spacer()
             }
             .sheet(item: $checkTabState.feedbackConfig) { feedbackConfig in
@@ -36,8 +35,8 @@ struct CheckTab: View {
                     case .productImages(let productImages):
                         LabelAnalysisView(productImages: productImages)
                             .environment(checkTabState)
-                    case .barcode:
-                        BarcodeAnalysisView(barcode: $barcode)
+                    case .barcode(let barcode):
+                        BarcodeAnalysisView(barcode: barcode)
                             .environment(checkTabState)
                 }
             }


### PR DESCRIPTION
## Summary
- push barcode payloads through navigation routes to avoid duplicate analysis pushes
- reset scanner haptics and routing guard so only unique scans trigger feedback
- add AGENTS.md with tailored contributor guidance for IngrediCheck

## Testing
- Not run (scanner logic requires device)
